### PR TITLE
Add navbar with about and contact pages

### DIFF
--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -1,0 +1,15 @@
+export const metadata = {
+  title: 'About - Northeast Web Studio',
+  description: 'Learn more about Northeast Web Studio',
+};
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-[#1c1c1e] to-[#2f2f31] text-zinc-100 p-8 space-y-4">
+      <h1 className="text-4xl font-bold text-amber-400">About Us</h1>
+      <p className="text-zinc-300 max-w-2xl">
+        We craft websites for local businesses in Cleveland and beyond. Quality and reliability are at the core of every project.
+      </p>
+    </main>
+  );
+}

--- a/src/app/components/Navbar.js
+++ b/src/app/components/Navbar.js
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+export default function Navbar() {
+  return (
+    <nav className="bg-zinc-900 text-zinc-100 p-4 flex space-x-6 shadow-md">
+      <Link href="/" className="font-semibold text-amber-400 hover:text-amber-300">
+        Home
+      </Link>
+      <Link href="/about" className="hover:text-amber-300">
+        About
+      </Link>
+      <Link href="/contact" className="hover:text-amber-300">
+        Contact
+      </Link>
+    </nav>
+  );
+}

--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -1,0 +1,19 @@
+export const metadata = {
+  title: 'Contact - Northeast Web Studio',
+  description: 'Get in touch with Northeast Web Studio',
+};
+
+export default function ContactPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-[#1c1c1e] to-[#2f2f31] text-zinc-100 p-8 space-y-4">
+      <h1 className="text-4xl font-bold text-amber-400">Contact</h1>
+      <p className="text-zinc-300">
+        Email us at{' '}
+        <a href="mailto:sydneywells103@gmail.com" className="text-amber-300 underline">
+          sydneywells103@gmail.com
+        </a>
+        . We look forward to hearing from you.
+      </p>
+    </main>
+  );
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,6 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navbar from "./components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -22,6 +23,7 @@ export default function RootLayout({ children }) {
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Navbar />
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- implement a `Navbar` component with links
- show the navbar in `layout.js`
- add `/about` and `/contact` pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819f7da4d883279f1957b37b15c0af