### PR TITLE
Add sample sites page

### DIFF
--- a/src/app/components/Navbar.js
+++ b/src/app/components/Navbar.js
@@ -9,6 +9,9 @@ export default function Navbar() {
       <Link href="/about" className="hover:text-amber-300">
         About
       </Link>
+      <Link href="/samples" className="hover:text-amber-300">
+        Samples
+      </Link>
       <Link href="/contact" className="hover:text-amber-300">
         Contact
       </Link>

--- a/src/app/samples/page.js
+++ b/src/app/samples/page.js
@@ -1,0 +1,46 @@
+export const metadata = {
+  title: 'Sample Sites - Northeast Web Studio',
+  description: 'Preview sample websites built by Northeast Web Studio',
+};
+
+import Link from 'next/link';
+
+const sites = [
+  {
+    title: 'Sample Site One',
+    href: '/samples/site1',
+    snippet: 'A clean landing page design for a cozy coffee shop.',
+  },
+  {
+    title: 'Sample Site Two',
+    href: '/samples/site2',
+    snippet: 'Modern portfolio layout showcasing projects and services.',
+  },
+  {
+    title: 'Sample Site Three',
+    href: '/samples/site3',
+    snippet: 'Simple blog homepage with inviting typography.',
+  },
+  {
+    title: 'Sample Site Four',
+    href: '/samples/site4',
+    snippet: 'Event landing page featuring a strong call to action.',
+  },
+];
+
+export default function SamplesPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-[#1c1c1e] to-[#2f2f31] text-zinc-100 p-8 space-y-8">
+      <h1 className="text-4xl font-bold text-amber-400 text-center">Sample Sites</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {sites.map((site) => (
+          <div key={site.href} className="bg-zinc-800 border border-zinc-700 p-6 rounded-xl space-y-3 shadow">
+            <h2 className="text-2xl font-semibold text-amber-300">{site.title}</h2>
+            <p className="text-zinc-300">{site.snippet}</p>
+            <Link href={site.href} className="text-amber-400 underline">Visit Site</Link>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/samples/site1/page.js
+++ b/src/app/samples/site1/page.js
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: 'Sample Site 1 - Northeast Web Studio',
+};
+
+export default function Site1() {
+  return (
+    <main className="min-h-screen bg-white text-gray-900 p-8 space-y-4">
+      <h1 className="text-4xl font-bold text-center">Sample Site One</h1>
+      <p className="max-w-2xl mx-auto text-center">
+        Welcome to the first sample site. This simple landing page demonstrates a clean layout for a local coffee shop.
+      </p>
+    </main>
+  );
+}

--- a/src/app/samples/site2/page.js
+++ b/src/app/samples/site2/page.js
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: 'Sample Site 2 - Northeast Web Studio',
+};
+
+export default function Site2() {
+  return (
+    <main className="min-h-screen bg-white text-gray-900 p-8 space-y-4">
+      <h1 className="text-4xl font-bold text-center">Sample Site Two</h1>
+      <p className="max-w-2xl mx-auto text-center">
+        This example site highlights a modern portfolio design suitable for freelancers and agencies alike.
+      </p>
+    </main>
+  );
+}

--- a/src/app/samples/site3/page.js
+++ b/src/app/samples/site3/page.js
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: 'Sample Site 3 - Northeast Web Studio',
+};
+
+export default function Site3() {
+  return (
+    <main className="min-h-screen bg-white text-gray-900 p-8 space-y-4">
+      <h1 className="text-4xl font-bold text-center">Sample Site Three</h1>
+      <p className="max-w-2xl mx-auto text-center">
+        Here we showcase a simple blog homepage layout with clear typography and an inviting hero section.
+      </p>
+    </main>
+  );
+}

--- a/src/app/samples/site4/page.js
+++ b/src/app/samples/site4/page.js
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: 'Sample Site 4 - Northeast Web Studio',
+};
+
+export default function Site4() {
+  return (
+    <main className="min-h-screen bg-white text-gray-900 p-8 space-y-4">
+      <h1 className="text-4xl font-bold text-center">Sample Site Four</h1>
+      <p className="max-w-2xl mx-auto text-center">
+        This fourth demo illustrates an event landing page with a bold call to action and modern color palette.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- showcase four sample sites with links
- add a navbar link for the new page
- add minimal pages for each sample site

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a2656fec832780f3bd43611f0239