### PR TITLE
Fix metadata export

### DIFF
--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -2,11 +2,6 @@
 
 import { useState } from 'react';
 
-export const metadata = {
-  title: 'Contact - Northeast Web Studio',
-  description: 'Get in touch with Northeast Web Studio',
-};
-
 export default function ContactPage() {
   const [form, setForm] = useState({ name: '', email: '', message: '' });
   const [status, setStatus] = useState('');


### PR DESCRIPTION
## Summary
- remove metadata export from the `contact` page to avoid Next.js build errors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881aa2e7fc08327ae23d4d93ff65bb0