### PR TITLE
Fix mismatched image filenames

### DIFF
--- a/src/app/samples/page.js
+++ b/src/app/samples/page.js
@@ -17,13 +17,13 @@ const sites = [
     title: 'Pop-up Shop',
     href: 'https://popupshop-site.vercel.app/',
     snippet: 'Modern portfolio layout showcasing projects and services.',
-    image: '/images/pop-up.png',
+    image: '/images/Pop-up.png',
   },
   {
     title: 'Photography',
     href: 'https://photography-site-brown.vercel.app/',
     snippet: 'Simple blog homepage with inviting typography.',
-    image: '/images/photography.png',
+    image: '/images/Photography.png',
   },
   {
     title: 'Custom',


### PR DESCRIPTION
## Summary
- fix case-sensitive filename paths on the samples page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882828808048327ac6899fed99fc493