### PR TITLE
Add home navigation links to sample pages

### DIFF
--- a/src/app/samples/page.js
+++ b/src/app/samples/page.js
@@ -49,7 +49,14 @@ export default function SamplesPage() {
             />
             <h2 className="text-2xl font-semibold text-amber-300">{site.title}</h2>
             <p className="text-zinc-300">{site.snippet}</p>
-            <Link href={site.href} className="text-amber-400 underline">Visit Site</Link>
+            <Link
+              href={site.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-amber-400 underline"
+            >
+              Visit Site
+            </Link>
           </div>
         ))}
       </div>

--- a/src/app/samples/site1/page.js
+++ b/src/app/samples/site1/page.js
@@ -2,6 +2,8 @@ export const metadata = {
   title: 'Sample Site 1 - Northeast Web Studio',
 };
 
+import Link from 'next/link';
+
 export default function Site1() {
   return (
     <main className="min-h-screen bg-white text-gray-900 p-8 space-y-4">
@@ -9,6 +11,11 @@ export default function Site1() {
       <p className="max-w-2xl mx-auto text-center">
         Welcome to the first sample site. This simple landing page demonstrates a clean layout for a local coffee shop.
       </p>
+      <div className="text-center mt-6">
+        <Link href="/" className="text-amber-600 underline">
+          Back to Home
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/app/samples/site2/page.js
+++ b/src/app/samples/site2/page.js
@@ -2,6 +2,8 @@ export const metadata = {
   title: 'Sample Site 2 - Northeast Web Studio',
 };
 
+import Link from 'next/link';
+
 export default function Site2() {
   return (
     <main className="min-h-screen bg-white text-gray-900 p-8 space-y-4">
@@ -9,6 +11,11 @@ export default function Site2() {
       <p className="max-w-2xl mx-auto text-center">
         This example site highlights a modern portfolio design suitable for freelancers and agencies alike.
       </p>
+      <div className="text-center mt-6">
+        <Link href="/" className="text-amber-600 underline">
+          Back to Home
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/app/samples/site3/page.js
+++ b/src/app/samples/site3/page.js
@@ -2,6 +2,8 @@ export const metadata = {
   title: 'Sample Site 3 - Northeast Web Studio',
 };
 
+import Link from 'next/link';
+
 export default function Site3() {
   return (
     <main className="min-h-screen bg-white text-gray-900 p-8 space-y-4">
@@ -9,6 +11,11 @@ export default function Site3() {
       <p className="max-w-2xl mx-auto text-center">
         Here we showcase a simple blog homepage layout with clear typography and an inviting hero section.
       </p>
+      <div className="text-center mt-6">
+        <Link href="/" className="text-amber-600 underline">
+          Back to Home
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/app/samples/site4/page.js
+++ b/src/app/samples/site4/page.js
@@ -2,6 +2,8 @@ export const metadata = {
   title: 'Sample Site 4 - Northeast Web Studio',
 };
 
+import Link from 'next/link';
+
 export default function Site4() {
   return (
     <main className="min-h-screen bg-white text-gray-900 p-8 space-y-4">
@@ -10,6 +12,11 @@ export default function Site4() {
       <p className="max-w-2xl mx-auto text-center">
         This fourth demo illustrates an event landing page with a bold call to action and modern color palette.
       </p>
+      <div className="text-center mt-6">
+        <Link href="/" className="text-amber-600 underline">
+          Back to Home
+        </Link>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add explicit "Back to Home" links on each sample demo page
- open external sample links in a new tab

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_688302cefa9c832782d1af7ceb41606d