### PR TITLE
Integrate Formsubmit for contact forms

### DIFF
--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -14,11 +14,17 @@ export default function ContactPage() {
     e.preventDefault();
     setStatus('Sending...');
     try {
-      const res = await fetch('/api/message', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
-      });
+      const res = await fetch(
+        'https://formsubmit.co/ajax/sydneywells103@gmail.com',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify(form),
+        }
+      );
       if (res.ok) {
         setStatus('Message sent!');
         setForm({ name: '', email: '', message: '' });

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -15,11 +15,17 @@ export default function Home() {
     e.preventDefault();
     setStatus('Sending...');
     try {
-      const res = await fetch('/api/message', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
-      });
+      const res = await fetch(
+        'https://formsubmit.co/ajax/sydneywells103@gmail.com',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify(form),
+        }
+      );
       if (res.ok) {
         setStatus('Message sent!');
         setForm({ name: '', email: '', message: '' });


### PR DESCRIPTION
## Summary
- route contact forms directly to Formsubmit
- update both contact form handlers on the home and contact pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884092aa0a08327b97887d90b1f1bed