### PR TITLE
Add targeted business section on home page

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -50,6 +50,12 @@ export default function Home() {
           <p className="text-lg md:text-xl text-zinc-300 max-w-md">
             Affordable, mobile-friendly websites for local businesses. Get online fast—with a site that works as hard as you do.
           </p>
+          <p className="text-lg md:text-xl text-zinc-300 max-w-md">
+            Perfect for: Food trucks, boutiques, contractors, and local shops.
+          </p>
+          <p className="text-lg md:text-xl text-zinc-300 max-w-md">
+            I handle everything—domain, design, hosting—so you can focus on running your business.
+          </p>
         </div>
         <Image
           src="/images/building (1).png"


### PR DESCRIPTION
## Summary
- highlight businesses served and all-inclusive service approach on the home page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d1043f97083278a2b7d42c2f943cf