### PR TITLE
Add home page samples preview

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,10 +3,12 @@
 import { useState } from 'react';
 import Image from "next/image";
 import Link from "next/link";
+import { sampleSites } from "../data/sampleSites";
 
 export default function Home() {
   const [form, setForm] = useState({ name: '', email: '', message: '' });
   const [status, setStatus] = useState('');
+  const previewSites = sampleSites.slice(0, 3);
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -94,6 +96,30 @@ export default function Home() {
         <p>
           <Link href="/services" className="text-amber-300 underline">
             View full service details
+          </Link>
+        </p>
+      </section>
+
+      <section className="max-w-6xl mx-auto text-center space-y-6">
+        <h2 className="text-4xl font-bold text-amber-400 drop-shadow">Samples</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+          {previewSites.map((site) => (
+            <div key={site.href} className="bg-zinc-800 border border-zinc-700 rounded-xl p-4 space-y-2 shadow">
+              <Image
+                src={site.image}
+                alt={`${site.title} preview`}
+                width={400}
+                height={250}
+                className="rounded-lg w-full object-cover"
+              />
+              <h3 className="text-xl font-semibold text-amber-300">{site.title}</h3>
+              <p className="text-zinc-300 text-sm">{site.snippet}</p>
+            </div>
+          ))}
+        </div>
+        <p>
+          <Link href="/samples" className="text-amber-300 underline">
+            View all sample sites
           </Link>
         </p>
       </section>

--- a/src/app/samples/page.js
+++ b/src/app/samples/page.js
@@ -5,45 +5,7 @@ export const metadata = {
 
 import Link from 'next/link';
 import Image from 'next/image';
-
-const sites = [
-  {
-    title: 'Food Trucks',
-    href: 'https://foodtruck-site.vercel.app',
-    snippet: 'A clean landing page design for a food truck.',
-    image: '/images/foodtruck.png', // Add your image path here
-  },
-   {
-    title: 'Pet Salon',
-    href: 'https://dogwash-site.vercel.app/',
-    snippet: 'Modern portfolio layout showcasing projects.',
-    image: '/images/dogwash.png',
-  },
-  {
-    title: 'Pop-up Shop',
-    href: 'https://popupshop-site.vercel.app/',
-    snippet: 'Modern portfolio layout showcasing projects.',
-    image: '/images/Pop-up.png',
-  },
-  {
-    title: 'Photography',
-    href: 'https://photography-site-brown.vercel.app/',
-    snippet: 'Simple photography blog homepage with inviting typography.',
-    image: '/images/Photography.png',
-  },
-    {
-    title: 'Tattoo Shop',
-    href: 'https://tattoo-site.vercel.app/',
-    snippet: 'Edgy multi-page layout for local tattoo artists.',
-    image: '/images/tattoo.png',
-  },
-  {
-    title: 'Custom',
-    href: 'https://oddjobs-site.vercel.app/',
-    snippet: 'Event landing page featuring a strong call to action.',
-    image: '/images/oddjobs.png',
-  },
-];
+import { sampleSites as sites } from '../../data/sampleSites';
 
 export default function SamplesPage() {
   return (

--- a/src/data/sampleSites.js
+++ b/src/data/sampleSites.js
@@ -1,0 +1,38 @@
+export const sampleSites = [
+  {
+    title: 'Food Trucks',
+    href: 'https://foodtruck-site.vercel.app',
+    snippet: 'A clean landing page design for a food truck.',
+    image: '/images/foodtruck.png',
+  },
+  {
+    title: 'Pet Salon',
+    href: 'https://dogwash-site.vercel.app/',
+    snippet: 'Modern portfolio layout showcasing projects.',
+    image: '/images/dogwash.png',
+  },
+  {
+    title: 'Pop-up Shop',
+    href: 'https://popupshop-site.vercel.app/',
+    snippet: 'Modern portfolio layout showcasing projects.',
+    image: '/images/Pop-up.png',
+  },
+  {
+    title: 'Photography',
+    href: 'https://photography-site-brown.vercel.app/',
+    snippet: 'Simple photography blog homepage with inviting typography.',
+    image: '/images/Photography.png',
+  },
+  {
+    title: 'Tattoo Shop',
+    href: 'https://tattoo-site.vercel.app/',
+    snippet: 'Edgy multi-page layout for local tattoo artists.',
+    image: '/images/tattoo.png',
+  },
+  {
+    title: 'Custom',
+    href: 'https://oddjobs-site.vercel.app/',
+    snippet: 'Event landing page featuring a strong call to action.',
+    image: '/images/oddjobs.png',
+  },
+];


### PR DESCRIPTION
## Summary
- centralize sample site data in `src/data/sampleSites.js`
- reference shared sample site data in `/samples` page
- show a preview of the first three sample sites on the home page with a link to the full Samples page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688d116322e483279422fe13fcad208f