### PR TITLE
Revert UI redesign and keep about-section reorder

### DIFF
--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -74,7 +74,7 @@ export default function ContactPage() {
           />
           <button
             type="submit"
-            className="bg-yellow-400 hover:bg-orange-500 text-black font-bold py-2 px-4 rounded w-full"
+            className="bg-amber-500 hover:bg-amber-600 text-white font-semibold py-2 px-4 rounded w-full"
           >
             Send
           </button>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -43,28 +43,25 @@ export default function Home() {
     <main className="min-h-screen bg-gradient-to-b from-[#1c1c1e] to-[#2f2f31] text-zinc-100 px-4 sm:px-8 py-12 space-y-16 font-sans">
       <section className="max-w-6xl mx-auto grid md:grid-cols-2 gap-12 items-center">
         <div className="space-y-6 text-center md:text-left order-last md:order-first">
-          <h1 className="text-5xl md:text-6xl font-extrabold text-amber-400 drop-shadow">
+          <h1 className="text-5xl md:text-6xl font-extrabold text-amber-400 tracking-tight drop-shadow">
             Northeast Web Studio
           </h1>
-          <p className="text-lg md:text-xl text-zinc-300 max-w-md mx-auto md:mx-0">
-            Clean, fast websites built in the Rust Belt.
+          <p className="text-lg md:text-xl text-zinc-300 max-w-md">
+            Web design forged in the Rust Belt. Clean. Fast. Built to last.
           </p>
-          <ul className="text-zinc-300 space-y-1 md:list-disc md:pl-6 text-left md:text-left max-w-md mx-auto md:mx-0">
-            <li>🍔 Food trucks</li>
-            <li>🛍️ Boutiques</li>
-            <li>🔨 Contractors</li>
-            <li>🏪 Local shops</li>
-          </ul>
-          <Link
-            href="/contact"
-            className="inline-block bg-yellow-400 hover:bg-orange-500 text-black font-bold py-2 px-4 rounded"
-          >
-            Get a Free Quote
-          </Link>
+          <p className="text-lg md:text-xl text-zinc-300 max-w-md">
+            Affordable, mobile-friendly websites for local businesses. Get online fast—with a site that works as hard as you do.
+          </p>
+          <p className="text-lg md:text-xl text-zinc-300 max-w-md">
+            Perfect for: Food trucks, boutiques, contractors, and local shops.
+          </p>
+          <p className="text-lg md:text-xl text-zinc-300 max-w-md">
+            I handle everything—domain, design, hosting—so you can focus on running your business.
+          </p>
         </div>
         <Image
-          src="/images/foodtruck.png"
-          alt="Website demo"
+          src="/images/building (1).png"
+          alt="Rust Belt theme"
           width={1200}
           height={800}
           priority
@@ -86,7 +83,7 @@ export default function Home() {
         </ul>
         <Link
           href="/services"
-          className="inline-block bg-yellow-400 hover:bg-orange-500 text-black font-bold py-2 px-4 rounded"
+          className="inline-block bg-amber-500 hover:bg-amber-600 text-white font-semibold py-2 px-4 rounded"
         >
           View Full Service Details
         </Link>
@@ -172,7 +169,7 @@ export default function Home() {
           />
           <button
             type="submit"
-            className="bg-yellow-400 hover:bg-orange-500 text-black font-bold py-2 px-4 rounded w-full"
+            className="bg-amber-500 hover:bg-amber-600 text-white font-semibold py-2 px-4 rounded w-full"
           >
             Send
           </button>


### PR DESCRIPTION
## Summary
- restore original hero text and imagery
- revert button styles to amber on home and contact pages
- keep About section positioned above the Contact form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689109d50ffc83279b575cbe19d8b455