### PR TITLE
Add Request a Demo button to navbar

### DIFF
--- a/src/app/components/Navbar.js
+++ b/src/app/components/Navbar.js
@@ -11,12 +11,20 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="bg-zinc-900 text-zinc-100 p-4 flex space-x-6 shadow-md">
-      <Link href="/" className={linkClasses('/')}>Home</Link>
-      <Link href="/about" className={linkClasses('/about')}>About</Link>
-      <Link href="/services" className={linkClasses('/services')}>Services</Link>
-      <Link href="/samples" className={linkClasses('/samples')}>Samples</Link>
-      <Link href="/contact" className={linkClasses('/contact')}>Contact</Link>
+    <nav className="bg-zinc-900 text-zinc-100 p-4 flex items-center shadow-md">
+      <div className="flex space-x-6">
+        <Link href="/" className={linkClasses('/')}>Home</Link>
+        <Link href="/about" className={linkClasses('/about')}>About</Link>
+        <Link href="/services" className={linkClasses('/services')}>Services</Link>
+        <Link href="/samples" className={linkClasses('/samples')}>Samples</Link>
+        <Link href="/contact" className={linkClasses('/contact')}>Contact</Link>
+      </div>
+      <Link
+        href="/contact#contact-form"
+        className="ml-auto bg-amber-500 hover:bg-amber-600 text-white font-semibold px-4 py-2 rounded"
+      >
+        Request a Demo
+      </Link>
     </nav>
   );
 }

--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -44,7 +44,7 @@ export default function ContactPage() {
       </p>
       <div className="bg-zinc-900 rounded-xl p-8 max-w-xl mx-auto shadow-inner border border-zinc-700 space-y-4 text-center">
         <h2 className="text-2xl font-bold text-amber-400">Send a Message</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form id="contact-form" onSubmit={handleSubmit} className="space-y-4">
           <input
             type="text"
             name="name"


### PR DESCRIPTION
## Summary
- add a prominent Request a Demo button in the navbar linking to the contact form
- tag the contact form with an id for direct navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894d24ca0a883278512c3dbe9de5f27