### PR TITLE
Remove home page contact form

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,44 +1,10 @@
-'use client';
 // Template: Rust Belt-Inspired Web Services Site — Moody + Cool Look
-import { useState } from 'react';
 import Image from "next/image";
 import Link from "next/link";
 import { sampleSites } from "../data/sampleSites";
 
 export default function Home() {
-  const [form, setForm] = useState({ name: '', email: '', message: '' });
-  const [status, setStatus] = useState('');
   const previewSites = sampleSites.slice(0, 3);
-
-  const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
-  };
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setStatus('Sending...');
-    try {
-      const res = await fetch(
-        'https://formsubmit.co/ajax/sydneywells103@gmail.com',
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-          body: JSON.stringify(form),
-        }
-      );
-      if (res.ok) {
-        setStatus('Message sent!');
-        setForm({ name: '', email: '', message: '' });
-      } else {
-        setStatus('Failed to send.');
-      }
-    } catch {
-      setStatus('Failed to send.');
-    }
-  };
   return (
     <main className="min-h-screen bg-gradient-to-b from-[#1c1c1e] to-[#2f2f31] text-zinc-100 px-4 sm:px-8 py-12 space-y-16 font-sans">
       <section className="max-w-6xl mx-auto grid md:grid-cols-2 gap-12 items-center">
@@ -133,50 +99,15 @@ export default function Home() {
 
       <section className="max-w-xl mx-auto bg-zinc-900 rounded-xl p-8 text-center space-y-4 shadow-inner border border-zinc-700">
         <h2 className="text-3xl font-bold text-amber-400">Contact</h2>
-        <p className="text-lg text-zinc-300">Want a website or have a question? Let&apos;s talk.</p>
-
-        <p>Email: <a href="mailto:sydneywells103@gmail.com" className="text-amber-300 underline">sydneywells103@gmail.com</a></p>
-        <p className="text-zinc-400">Based in Northeast Ohio and proud to serve small businesses in the Cleveland area.</p>
-
-        <h3 className="text-2xl font-bold text-amber-400 mt-6">Send a Message</h3>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            name="name"
-            value={form.name}
-            onChange={handleChange}
-            placeholder="Your name"
-            required
-            className="w-full p-2 rounded bg-zinc-800 border border-zinc-700"
-          />
-          <input
-            type="email"
-            name="email"
-            value={form.email}
-            onChange={handleChange}
-            placeholder="Email"
-            required
-            className="w-full p-2 rounded bg-zinc-800 border border-zinc-700"
-          />
-          <textarea
-            name="message"
-            value={form.message}
-            onChange={handleChange}
-            placeholder="Message"
-            rows="4"
-            required
-            className="w-full p-2 rounded bg-zinc-800 border border-zinc-700"
-          />
-          <button
-            type="submit"
-            className="bg-amber-500 hover:bg-amber-600 text-white font-semibold py-2 px-4 rounded w-full"
-          >
-            Send
-          </button>
-          {status && (
-            <p className="text-sm text-center text-amber-300">{status}</p>
-          )}
-        </form>
+        <p className="text-lg text-zinc-300">
+          Ready to see what we can build? Visit our contact page to request a demo or reach out.
+        </p>
+        <Link
+          href="/contact"
+          className="inline-block bg-amber-500 hover:bg-amber-600 text-white font-semibold py-2 px-4 rounded"
+        >
+          Go to Contact Page
+        </Link>
       </section>
 
       <p className="text-xs text-zinc-500 text-center pt-8">


### PR DESCRIPTION
## Summary
- replace landing page contact form with call-to-action linking to the dedicated contact page
- remove unused client-side form state and handlers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894dbf410e8832793ded3406954d1ee