### PR TITLE
Align landing page service offerings with Services page details

### DIFF
--- a/src/app/components/ServiceCards.js
+++ b/src/app/components/ServiceCards.js
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+import { services } from '../../data/services';
+
+export default function ServiceCards() {
+  return (
+    <section
+      id="services"
+      className="reveal py-24 max-w-6xl mx-auto px-6 text-center"
+    >
+      <h2 className="text-4xl font-bold mb-12">Services</h2>
+      <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 text-left">
+        {services.map((service) => (
+          <div
+            key={service.name}
+            className={`relative flex flex-col h-full rounded-2xl border p-6 md:p-8 shadow-sm space-y-4 transition-transform duration-200 hover:shadow-md motion-safe:hover:-translate-y-1 motion-reduce:hover:transform-none bg-white dark:bg-zinc-800 ${service.featured ? 'ring-2 ring-amber-400 bg-amber-50 dark:bg-amber-900/20' : ''}`}
+          >
+            {service.tag && (
+              <span className="absolute right-4 top-4 bg-amber-500 text-white text-xs font-medium px-2 py-1 rounded-full">
+                {service.tag}{/* Edit badge text in services data */}
+              </span>
+            )}
+            <h3 className="text-2xl font-semibold">{service.name}</h3>
+            <p className="text-3xl font-semibold text-amber-500">
+              {service.price}{/* Edit price in services data */}
+            </p>
+            <p className="text-sm text-zinc-600 dark:text-zinc-300">
+              {service.bestFor}
+            </p>
+            <div>
+              <h4 className="font-semibold">Features</h4>
+              <ul className="list-disc list-inside text-sm leading-tight space-y-1">
+                {service.features.slice(0, 5).map((feat) => (
+                  <li key={feat}>{feat}{/* Edit feature bullets in services data */}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-semibold">Why choose this</h4>
+              <ul className="list-disc list-inside text-sm leading-tight space-y-1">
+                {service.whyChoose.slice(0, 5).map((why) => (
+                  <li key={why}>{why}{/* Edit why-choose bullets in services data */}</li>
+                ))}
+              </ul>
+            </div>
+            <Link
+              href="/#contact"
+              aria-label={`${service.cta} – ${service.name}`}
+              className="mt-auto w-full text-center bg-amber-500 hover:bg-amber-600 text-white font-semibold py-2 px-4 rounded-md transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500"
+            >
+              {service.cta}{/* Edit CTA text in services data */}
+            </Link>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -4,54 +4,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect } from "react";
 import { sampleSites } from "../data/sampleSites";
+import ServiceCards from "./components/ServiceCards";
 
 export default function Home() {
   const previewSites = sampleSites.slice(0, 6);
 
-  const services = [
-    {
-      name: "Starter Site",
-      price: "$300–$500",
-      bestFor:
-        "Best for small businesses, food trucks, or pop-up shops that need a simple online presence fast.",
-      features: [
-        "Up to 3 pages (Home, About, Contact)",
-        "Mobile-friendly responsive design",
-        "Basic SEO setup (page titles, meta descriptions)",
-        "1 round of revisions",
-        "30 days post-launch support",
-      ],
-      cta: "Get Started",
-    },
-    {
-      name: "Multi-Page Site",
-      price: "$800–$1,000",
-      bestFor:
-        "Best for growing businesses that want more space for content, features, and a polished user experience.",
-      features: [
-        "Up to 6 pages (Home, About, Services, Portfolio, Blog, Contact)",
-        "Mobile-friendly responsive design",
-        "Basic SEO setup + image optimization",
-        "2 rounds of revisions",
-        "45 days post-launch support",
-      ],
-      cta: "Get Started",
-    },
-    {
-      name: "Maintenance Plans",
-      price: "Basic $40/mo · VIP $80/mo",
-      bestFor:
-        "Keep your site running smoothly, secure, and up to date.",
-      features: [
-        "Hosting help & uptime monitoring",
-        "1 minor content update per week (Basic)",
-        "Priority support & regular updates (VIP)",
-        "Security checks & backups",
-      ],
-      cta: "Get Started",
-      highlight: true,
-    },
-  ];
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -114,37 +71,7 @@ export default function Home() {
       </section>
 
       {/* Services Section */}
-      <section
-        id="services"
-        className="reveal py-24 max-w-6xl mx-auto px-6 text-center"
-      >
-        <h2 className="text-4xl font-bold mb-12">Services</h2>
-        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 text-left">
-          {services.map((service) => (
-            <div
-              key={service.name}
-              className={`flex flex-col h-full rounded-xl p-8 shadow-md hover:shadow-xl transition-transform transform hover:-translate-y-1 bg-white dark:bg-zinc-800 ${service.highlight ? 'bg-amber-50 dark:bg-amber-900/20 border-2 border-amber-400' : ''}`}
-            >
-              <h3 className="text-2xl font-semibold mb-1">{service.name}</h3>
-              <p className="text-3xl font-bold text-amber-500 mb-2">{service.price}</p>
-              <p className="text-sm text-zinc-600 dark:text-zinc-300 mb-4">
-                {service.bestFor}
-              </p>
-              <ul className="list-disc list-inside space-y-2 text-sm text-zinc-600 dark:text-zinc-300 flex-1">
-                {service.features.map((feat) => (
-                  <li key={feat}>{feat}</li>
-                ))}
-              </ul>
-              <Link
-                href="/#contact"
-                className="mt-6 inline-block bg-amber-500 hover:bg-amber-600 text-white font-semibold text-center py-2 px-4 rounded-md"
-              >
-                {service.cta}
-              </Link>
-            </div>
-          ))}
-        </div>
-      </section>
+      <ServiceCards />
 
       {/* Portfolio Section */}
       <section

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -38,19 +38,6 @@ export default function Home() {
       cta: "Get Started",
     },
     {
-      name: "Hourly Work",
-      price: "$30/hour",
-      bestFor:
-        "Need changes to your existing site or want a unique feature added?",
-      features: [
-        "Site edits and updates",
-        "New page additions",
-        "Troubleshooting",
-        "Feature enhancements",
-      ],
-      cta: "Request Help",
-    },
-    {
       name: "Maintenance Plans",
       price: "Basic $40/mo · VIP $80/mo",
       bestFor:
@@ -63,17 +50,6 @@ export default function Home() {
       ],
       cta: "Get Started",
       highlight: true,
-    },
-    {
-      name: "Extras & Add-ons",
-      price: "Starting at $50",
-      bestFor: "Enhance your site with optional upgrades.",
-      features: [
-        "Domain + hosting setup",
-        "Simple logo design",
-        "Rush project delivery",
-      ],
-      cta: "Request a Quote",
     },
   ];
 
@@ -143,7 +119,7 @@ export default function Home() {
         className="reveal py-24 max-w-6xl mx-auto px-6 text-center"
       >
         <h2 className="text-4xl font-bold mb-12">Services</h2>
-        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-5 text-left">
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 text-left">
           {services.map((service) => (
             <div
               key={service.name}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -11,57 +11,69 @@ export default function Home() {
   const services = [
     {
       name: "Starter Site",
-      price: "$300",
-      bestFor: "Best for new businesses, food trucks, or pop-up shops.",
+      price: "$300–$500",
+      bestFor:
+        "Best for small businesses, food trucks, or pop-up shops that need a simple online presence fast.",
       features: [
         "Up to 3 pages (Home, About, Contact)",
-        "Mobile-friendly design",
-        "Basic SEO setup (titles, descriptions)",
+        "Mobile-friendly responsive design",
+        "Basic SEO setup (page titles, meta descriptions)",
         "1 round of revisions",
-        "Free 30-day post-launch support",
+        "30 days post-launch support",
       ],
       cta: "Get Started",
     },
     {
       name: "Multi-Page Site",
-      price: "$800",
-      bestFor: "Best for growing businesses wanting more content.",
+      price: "$800–$1,000",
+      bestFor:
+        "Best for growing businesses that want more space for content, features, and a polished user experience.",
       features: [
-        "Up to 6 pages",
-        "Mobile-friendly, responsive design",
+        "Up to 6 pages (Home, About, Services, Portfolio, Blog, Contact)",
+        "Mobile-friendly responsive design",
         "Basic SEO setup + image optimization",
         "2 rounds of revisions",
-        "Free 45-day post-launch support",
+        "45 days post-launch support",
       ],
       cta: "Get Started",
     },
     {
-      name: "Add-Ons",
-      price: "Custom Pricing",
-      bestFor: "Extra features to enhance your site.",
+      name: "Hourly Work",
+      price: "$30/hour",
+      bestFor:
+        "Need changes to your existing site or want a unique feature added?",
       features: [
-        "Extra pages",
-        "Blog setup",
-        "E-commerce store setup",
-        "Copywriting help",
-        "Domain + hosting assistance",
+        "Site edits and updates",
+        "New page additions",
+        "Troubleshooting",
+        "Feature enhancements",
       ],
-      cta: "Request a Demo",
+      cta: "Request Help",
     },
     {
-      name: "Monthly Maintenance",
-      price: "$50/month",
+      name: "Maintenance Plans",
+      price: "Basic $40/mo · VIP $80/mo",
       bestFor:
-        "For clients who want me to host their site and make regular updates.",
+        "Keep your site running smoothly, secure, and up to date.",
       features: [
-        "Fast, secure hosting",
-        "Monthly content updates (text, images, small changes)",
-        "Ongoing SEO monitoring & adjustments",
+        "Hosting help & uptime monitoring",
+        "1 minor content update per week (Basic)",
+        "Priority support & regular updates (VIP)",
         "Security checks & backups",
-        "Priority email support",
       ],
       cta: "Get Started",
       highlight: true,
+    },
+    {
+      name: "Extras & Add-ons",
+      price: "Starting at $50",
+      bestFor: "Enhance your site with optional upgrades.",
+      features: [
+        "Domain + hosting setup",
+        "Simple logo design",
+        "Rush project delivery",
+      ],
+      cta: "Request a Quote",
     },
   ];
 
@@ -131,7 +143,7 @@ export default function Home() {
         className="reveal py-24 max-w-6xl mx-auto px-6 text-center"
       >
         <h2 className="text-4xl font-bold mb-12">Services</h2>
-        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4 text-left">
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-5 text-left">
           {services.map((service) => (
             <div
               key={service.name}

--- a/src/data/services.js
+++ b/src/data/services.js
@@ -1,0 +1,70 @@
+export const services = [
+  {
+    name: 'Starter Site',
+    price: '$300–$500', // Edit price range
+    bestFor:
+      'Best for new businesses, food trucks, or pop-up shops that need a simple online presence fast.',
+    features: [
+      // Update feature bullets
+      'Up to 3 pages (Home, About, Contact)',
+      'Mobile-friendly responsive design',
+      'Basic SEO setup (titles, descriptions)',
+      '1 round of revisions',
+      'Free 30-day post-launch support',
+    ],
+    whyChoose: [
+      // Update “why choose” bullets
+      'Fastest turnaround (often ~1 week)',
+      'Lowest cost to get online',
+      'Perfect when you just need something up that looks professional',
+    ],
+    cta: 'Get Started', // Update CTA label
+    tag: 'Budget-friendly', // Change or remove badge
+  },
+  {
+    name: 'Multi-Page Site',
+    price: '$800–$1,000', // Edit price range
+    bestFor:
+      'Best for growing businesses that want more space for content, features, and a polished user experience.',
+    features: [
+      // Update feature bullets
+      'Up to 6 pages (e.g., Home, About, Services, Portfolio, Blog, Contact)',
+      'Mobile-friendly responsive design',
+      'Basic SEO setup + image optimization',
+      '2 rounds of revisions',
+      'Free 45-day post-launch support',
+    ],
+    whyChoose: [
+      // Update “why choose” bullets
+      'More room to tell your story & show work',
+      'Extra revisions for a refined look',
+      'Better performance with image optimization',
+      'Flexible base for future features',
+    ],
+    cta: 'Request a Demo', // Update CTA label
+    tag: 'Most Popular', // Change or remove badge
+    featured: true, // Highlight this card
+  },
+  {
+    name: 'Monthly Maintenance',
+    price: '$50/mo', // Edit price
+    bestFor:
+      'For clients who want hosting and regular updates without the hassle.',
+    features: [
+      // Update feature bullets
+      'Fast, secure hosting',
+      'Monthly content updates (text, images, small changes)',
+      'Ongoing SEO monitoring & quick fixes',
+      'Security checks & backups',
+      'Priority email support',
+    ],
+    whyChoose: [
+      // Update “why choose” bullets
+      'Keeps your site fresh and secure',
+      'Saves time with hassle-free updates',
+      'Affordable ongoing help',
+    ],
+    cta: 'Subscribe', // Update CTA label
+    tag: 'Hassle-free', // Change or remove badge
+  },
+];


### PR DESCRIPTION
## Summary
- refresh landing page services to mirror detailed packages, hourly work, maintenance plans, and add-ons
- expand services grid to accommodate new card

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68968b44d8f48327b834fd94b8881c31