### PR TITLE
feat: update services cards

### DIFF
--- a/src/app/components/ServiceCards.js
+++ b/src/app/components/ServiceCards.js
@@ -16,12 +16,12 @@ export default function ServiceCards() {
           >
             {service.tag && (
               <span className="absolute right-4 top-4 bg-amber-500 text-white text-xs font-medium px-2 py-1 rounded-full">
-                {service.tag}{/* Edit badge text in services data */}
+                {service.tag}
               </span>
             )}
             <h3 className="text-2xl font-semibold">{service.name}</h3>
             <p className="text-3xl font-semibold text-amber-500">
-              {service.price}{/* Edit price in services data */}
+              {service.price}
             </p>
             <p className="text-sm text-zinc-600 dark:text-zinc-300">
               {service.bestFor}
@@ -30,7 +30,7 @@ export default function ServiceCards() {
               <h4 className="font-semibold">Features</h4>
               <ul className="list-disc list-inside text-sm leading-tight space-y-1">
                 {service.features.slice(0, 5).map((feat) => (
-                  <li key={feat}>{feat}{/* Edit feature bullets in services data */}</li>
+                  <li key={feat}>{feat}</li>
                 ))}
               </ul>
             </div>
@@ -38,7 +38,7 @@ export default function ServiceCards() {
               <h4 className="font-semibold">Why choose this</h4>
               <ul className="list-disc list-inside text-sm leading-tight space-y-1">
                 {service.whyChoose.slice(0, 5).map((why) => (
-                  <li key={why}>{why}{/* Edit why-choose bullets in services data */}</li>
+                  <li key={why}>{why}</li>
                 ))}
               </ul>
             </div>
@@ -47,11 +47,14 @@ export default function ServiceCards() {
               aria-label={`${service.cta} – ${service.name}`}
               className="mt-auto w-full text-center bg-amber-500 hover:bg-amber-600 text-white font-semibold py-2 px-4 rounded-md transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500"
             >
-              {service.cta}{/* Edit CTA text in services data */}
+              {service.cta}
             </Link>
           </div>
         ))}
       </div>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mt-4 text-center max-w-2xl mx-auto">
+        All prices shown are estimates to help you understand the typical cost of a website based on your needs. Monthly maintenance is completely optional if you prefer to manage updates yourself.
+      </p>
     </section>
   );
 }

--- a/src/data/services.js
+++ b/src/data/services.js
@@ -1,11 +1,9 @@
 export const services = [
   {
     name: 'Starter Site',
-    price: '$300–$500', // Edit price range
-    bestFor:
-      'Best for new businesses, food trucks, or pop-up shops that need a simple online presence fast.',
+    price: '$300–$500',
+    bestFor: 'Best for new businesses, food trucks, or pop-up shops that need a simple online presence fast.',
     features: [
-      // Update feature bullets
       'Up to 3 pages (Home, About, Contact)',
       'Mobile-friendly responsive design',
       'Basic SEO setup (titles, descriptions)',
@@ -13,21 +11,18 @@ export const services = [
       'Free 30-day post-launch support',
     ],
     whyChoose: [
-      // Update “why choose” bullets
       'Fastest turnaround (often ~1 week)',
       'Lowest cost to get online',
       'Perfect when you just need something up that looks professional',
     ],
-    cta: 'Get Started', // Update CTA label
-    tag: 'Budget-friendly', // Change or remove badge
+    cta: 'Get Started',
+    tag: 'Budget-friendly',
   },
   {
     name: 'Multi-Page Site',
-    price: '$800–$1,000', // Edit price range
-    bestFor:
-      'Best for growing businesses that want more space for content, features, and a polished user experience.',
+    price: '$800–$1,000',
+    bestFor: 'Best for growing businesses that want more space for content, features, and a polished user experience.',
     features: [
-      // Update feature bullets
       'Up to 6 pages (e.g., Home, About, Services, Portfolio, Blog, Contact)',
       'Mobile-friendly responsive design',
       'Basic SEO setup + image optimization',
@@ -35,23 +30,20 @@ export const services = [
       'Free 45-day post-launch support',
     ],
     whyChoose: [
-      // Update “why choose” bullets
       'More room to tell your story & show work',
       'Extra revisions for a refined look',
       'Better performance with image optimization',
       'Flexible base for future features',
     ],
-    cta: 'Request a Demo', // Update CTA label
-    tag: 'Most Popular', // Change or remove badge
-    featured: true, // Highlight this card
+    cta: 'Request a Demo',
+    tag: 'Most Popular',
+    featured: true,
   },
   {
     name: 'Monthly Maintenance',
-    price: '$50-150/mo', // Edit price
-    bestFor:
-      'For clients who want hosting and regular updates without the hassle.',
+    price: '$50/mo',
+    bestFor: 'For clients who want hosting and regular updates without the hassle.',
     features: [
-      // Update feature bullets
       'Fast, secure hosting',
       'Monthly content updates (text, images, small changes)',
       'Ongoing SEO monitoring & quick fixes',
@@ -59,12 +51,11 @@ export const services = [
       'Priority email support',
     ],
     whyChoose: [
-      // Update “why choose” bullets
       'Keeps your site fresh and secure',
       'Saves time with hassle-free updates',
       'Affordable ongoing help',
     ],
-    cta: 'Subscribe', // Update CTA label
-    tag: 'Hassle-free', // Change or remove badge
+    cta: 'Subscribe',
+    tag: 'Hassle-free',
   },
 ];


### PR DESCRIPTION
## Summary
- refresh services dataset with updated pricing and why-choose points
- add note under service grid clarifying price estimates and optional maintenance

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c220cc1c83278cf5979a021841f5